### PR TITLE
fix: allow direct access to tinymce upload api endpoint

### DIFF
--- a/src/Controller/Api/Checklist/ItemController.php
+++ b/src/Controller/Api/Checklist/ItemController.php
@@ -4,6 +4,7 @@ namespace App\Controller\Api\Checklist;
 
 use App\Controller\AbstractController;
 use App\Controller\Trait\ApiControllerTrait;
+use App\Controller\Trait\PreventDirectAccessTrait;
 use App\Entity\Checklist\ItemGroup;
 use App\Mercure\UpdateType;
 use App\Repository\Checklist\ItemRepository;
@@ -18,6 +19,7 @@ use Symfony\Component\Routing\Annotation\Route;
 class ItemController extends AbstractController
 {
 	use ApiControllerTrait;
+	use PreventDirectAccessTrait;
 
 	/**
 	 * Returns the list of items for a given project's checklist.

--- a/src/Controller/Api/CommentController.php
+++ b/src/Controller/Api/CommentController.php
@@ -4,6 +4,7 @@ namespace App\Controller\Api;
 
 use App\Controller\AbstractController;
 use App\Controller\Trait\ApiControllerTrait;
+use App\Controller\Trait\PreventDirectAccessTrait;
 use App\Entity\Comment;
 use App\Mercure\UpdateType;
 use App\Repository\Checklist\ItemRepository;
@@ -22,6 +23,7 @@ use Symfony\Component\Routing\Annotation\Route;
 class CommentController extends AbstractController
 {
 	use ApiControllerTrait;
+	use PreventDirectAccessTrait;
 
 	/**
 	 * @Route("", methods={"GET","HEAD"}, name="list", options={"expose": true})

--- a/src/Controller/Api/FeedbackController.php
+++ b/src/Controller/Api/FeedbackController.php
@@ -4,6 +4,7 @@ namespace App\Controller\Api;
 
 use App\Controller\AbstractController;
 use App\Controller\Trait\ApiControllerTrait;
+use App\Controller\Trait\PreventDirectAccessTrait;
 use Symfony\Bridge\Twig\Mime\TemplatedEmail;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -17,6 +18,7 @@ use Symfony\Component\Routing\Annotation\Route;
 class FeedbackController extends AbstractController
 {
 	use ApiControllerTrait;
+	use PreventDirectAccessTrait;
 
 	/**
 	 * @Route("/submit", methods={"POST"}, name="submit", options={"expose": true})

--- a/src/Controller/Api/LinkMetasController.php
+++ b/src/Controller/Api/LinkMetasController.php
@@ -4,6 +4,7 @@ namespace App\Controller\Api;
 
 use App\Controller\AbstractController;
 use App\Controller\Trait\ApiControllerTrait;
+use App\Controller\Trait\PreventDirectAccessTrait;
 use App\Util\Meta\MetaFetcher;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -17,6 +18,7 @@ use Symfony\Contracts\Cache\ItemInterface;
 class LinkMetasController extends AbstractController
 {
 	use ApiControllerTrait;
+	use PreventDirectAccessTrait;
 
 	protected const CACHE_DURATION_IN_DAYS = 10;
 

--- a/src/Controller/Api/Organization/MembersController.php
+++ b/src/Controller/Api/Organization/MembersController.php
@@ -4,6 +4,7 @@ namespace App\Controller\Api\Organization;
 
 use App\Controller\AbstractController;
 use App\Controller\Trait\ApiControllerTrait;
+use App\Controller\Trait\PreventDirectAccessTrait;
 use App\Entity\OrganizationInvitation;
 use App\Entity\OrganizationMember;
 use App\Repository\OrganizationMemberRepository;
@@ -22,6 +23,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 class MembersController extends AbstractController
 {
 	use ApiControllerTrait;
+	use PreventDirectAccessTrait;
 
 	/**
 	 * @Route("", methods={"GET","HEAD"}, name="list", options={"expose": true})

--- a/src/Controller/Api/Organization/OrganizationController.php
+++ b/src/Controller/Api/Organization/OrganizationController.php
@@ -4,6 +4,7 @@ namespace App\Controller\Api\Organization;
 
 use App\Controller\AbstractController;
 use App\Controller\Trait\ApiControllerTrait;
+use App\Controller\Trait\PreventDirectAccessTrait;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\Routing\Annotation\Route;
 
@@ -13,6 +14,7 @@ use Symfony\Component\Routing\Annotation\Route;
 class OrganizationController extends AbstractController
 {
 	use ApiControllerTrait;
+	use PreventDirectAccessTrait;
 
 	/**
 	 * @Route("{id}", methods={"GET","HEAD"}, name="details", options={"expose": true})

--- a/src/Controller/Api/Project/AutomatedTestingSettingsController.php
+++ b/src/Controller/Api/Project/AutomatedTestingSettingsController.php
@@ -4,6 +4,7 @@ namespace App\Controller\Api\Project;
 
 use App\Controller\AbstractController;
 use App\Controller\Trait\ApiControllerTrait;
+use App\Controller\Trait\PreventDirectAccessTrait;
 use App\Util\Testing\AvailableToolsFetcher;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -15,6 +16,7 @@ use Symfony\Component\Routing\Annotation\Route;
 class AutomatedTestingSettingsController extends AbstractController
 {
 	use ApiControllerTrait;
+	use PreventDirectAccessTrait;
 
 	/**
 	 * @Route("/tools", methods={"GET","HEAD"}, name="tools_list", options={"expose": true})

--- a/src/Controller/Api/Project/PageController.php
+++ b/src/Controller/Api/Project/PageController.php
@@ -4,6 +4,7 @@ namespace App\Controller\Api\Project;
 
 use App\Controller\AbstractController;
 use App\Controller\Trait\ApiControllerTrait;
+use App\Controller\Trait\PreventDirectAccessTrait;
 use App\Entity\Page;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -15,6 +16,7 @@ use Symfony\Component\Routing\Annotation\Route;
 class PageController extends AbstractController
 {
 	use ApiControllerTrait;
+	use PreventDirectAccessTrait;
 
 	/**
 	 * @Route("", methods={"GET","HEAD"}, name="list", options={"expose": true})

--- a/src/Controller/Api/Project/ProjectController.php
+++ b/src/Controller/Api/Project/ProjectController.php
@@ -4,6 +4,7 @@ namespace App\Controller\Api\Project;
 
 use App\Controller\AbstractController;
 use App\Controller\Trait\ApiControllerTrait;
+use App\Controller\Trait\PreventDirectAccessTrait;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
@@ -14,6 +15,7 @@ use Symfony\Component\Routing\Annotation\Route;
 class ProjectController extends AbstractController
 {
 	use ApiControllerTrait;
+	use PreventDirectAccessTrait;
 
 	/**
 	 * @Route("", methods={"GET","HEAD"}, name="list", options={"expose": true})

--- a/src/Controller/Api/SearchController.php
+++ b/src/Controller/Api/SearchController.php
@@ -4,6 +4,7 @@ namespace App\Controller\Api;
 
 use App\Controller\AbstractController;
 use App\Controller\Trait\ApiControllerTrait;
+use App\Controller\Trait\PreventDirectAccessTrait;
 use App\Util\Search\SearchEngine;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -15,6 +16,7 @@ use Symfony\Component\Routing\Annotation\Route;
 class SearchController extends AbstractController
 {
 	use ApiControllerTrait;
+	use PreventDirectAccessTrait;
 
 	/**
 	 * @Route("", methods={"POST"}, name="", options={"expose": true})

--- a/src/Controller/Api/Testing/IgnoreEntriesController.php
+++ b/src/Controller/Api/Testing/IgnoreEntriesController.php
@@ -4,6 +4,7 @@ namespace App\Controller\Api\Testing;
 
 use App\Controller\AbstractController;
 use App\Controller\Trait\ApiControllerTrait;
+use App\Controller\Trait\PreventDirectAccessTrait;
 use App\Entity\Testing\IgnoreEntry;
 use App\Mercure\UpdateType;
 use App\Repository\Testing\IgnoreEntryRepository;
@@ -20,6 +21,7 @@ use Symfony\Component\Routing\Annotation\Route;
 class IgnoreEntriesController extends AbstractController
 {
 	use ApiControllerTrait;
+	use PreventDirectAccessTrait;
 
 	/**
 	 * @Route("", methods={"GET","HEAD"}, name="list", options={"expose": true})

--- a/src/Controller/Api/Testing/RecommendationController.php
+++ b/src/Controller/Api/Testing/RecommendationController.php
@@ -4,6 +4,7 @@ namespace App\Controller\Api\Testing;
 
 use App\Controller\AbstractController;
 use App\Controller\Trait\ApiControllerTrait;
+use App\Controller\Trait\PreventDirectAccessTrait;
 use App\Message\TestingRequest;
 use App\Repository\Testing\RecommendationRepository;
 use App\Security\ProjectVoter;
@@ -20,6 +21,7 @@ use Symfony\Component\Routing\Annotation\Route;
 class RecommendationController extends AbstractController
 {
 	use ApiControllerTrait;
+	use PreventDirectAccessTrait;
 
 	/**
 	 * Returns the list of recommendations for the project, grouped by type.

--- a/src/Controller/Api/Testing/TestingController.php
+++ b/src/Controller/Api/Testing/TestingController.php
@@ -5,6 +5,7 @@ namespace App\Controller\Api\Testing;
 use App\ApiClient\Endpoint\StatusEndpoint;
 use App\Controller\AbstractController;
 use App\Controller\Trait\ApiControllerTrait;
+use App\Controller\Trait\PreventDirectAccessTrait;
 use App\Message\TestingRequest;
 use App\Security\ProjectVoter;
 use App\Subscription\QuotaManager;
@@ -19,6 +20,7 @@ use Symfony\Component\Routing\Annotation\Route;
 class TestingController extends AbstractController
 {
 	use ApiControllerTrait;
+	use PreventDirectAccessTrait;
 
 	/**
 	 * Submits an automated testing request for the project.

--- a/src/Controller/Api/TinyMceUploadController.php
+++ b/src/Controller/Api/TinyMceUploadController.php
@@ -4,6 +4,7 @@ namespace App\Controller\Api;
 
 use App\Controller\AbstractController;
 use App\Controller\Trait\ApiControllerTrait;
+use App\Controller\Trait\PreventDirectAccessTrait;
 use App\Storage\UserUploadStorage;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\JsonResponse;

--- a/src/Controller/Api/User/SubscriptionController.php
+++ b/src/Controller/Api/User/SubscriptionController.php
@@ -4,6 +4,7 @@ namespace App\Controller\Api\User;
 
 use App\Controller\AbstractController;
 use App\Controller\Trait\ApiControllerTrait;
+use App\Controller\Trait\PreventDirectAccessTrait;
 use App\Subscription\SubscriptionUpdater;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -15,6 +16,7 @@ use Symfony\Component\Routing\Annotation\Route;
 class SubscriptionController extends AbstractController
 {
 	use ApiControllerTrait;
+	use PreventDirectAccessTrait;
 
 	/**
 	 * @Route("/change", methods={"POST","PUT"}, name="change_plan", options={"expose": true})

--- a/src/Controller/Api/UserController.php
+++ b/src/Controller/Api/UserController.php
@@ -4,6 +4,7 @@ namespace App\Controller\Api;
 
 use App\Controller\AbstractController;
 use App\Controller\Trait\ApiControllerTrait;
+use App\Controller\Trait\PreventDirectAccessTrait;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\Routing\Annotation\Route;
 
@@ -13,6 +14,7 @@ use Symfony\Component\Routing\Annotation\Route;
 class UserController extends AbstractController
 {
 	use ApiControllerTrait;
+	use PreventDirectAccessTrait;
 
 	/**
 	 * Returns data about the current user.

--- a/src/Controller/Trait/ApiControllerTrait.php
+++ b/src/Controller/Trait/ApiControllerTrait.php
@@ -41,21 +41,6 @@ trait ApiControllerTrait
 	}
 
 	/**
-	 * Prevents users from accessing API endpoints directly in their browser.
-	 *
-	 * This prevents users from clicking on API links from mischievous
-	 * people who might that might
-	 *
-	 * @required
-	 * */
-	public function preventDirectAccess(RequestStack $requestStack): void
-	{
-		if (!$requestStack->getCurrentRequest()->isXmlHttpRequest()) {
-			throw new BadRequestHttpException("Direct access to internal API endpoints is not allowed.", null, 400);
-		}
-	}
-
-	/**
 	 * @SuppressWarnings(PHPMD.ExitExpression)
 	 */
 	protected function getProject(int | string | null $id, string $privilege = ProjectVoter::VIEW): ?Project

--- a/src/Controller/Trait/PreventDirectAccessTrait.php
+++ b/src/Controller/Trait/PreventDirectAccessTrait.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Controller\Trait;
+
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+
+trait PreventDirectAccessTrait
+{
+	/**
+	 * Prevents users from accessing API endpoints directly in their browser.
+	 *
+	 * This prevents users from clicking on API links from mischievous
+	 * people who might that might
+	 *
+	 * @required
+	 * */
+	public function preventDirectAccess(RequestStack $requestStack): void
+	{
+		if (!$requestStack->getCurrentRequest()->isXmlHttpRequest()) {
+			throw new BadRequestHttpException("Direct access to internal API endpoints is not allowed.", null, 400);
+		}
+	}
+}


### PR DESCRIPTION
To do so, the direct access denial has been moved into its own trait. This will also make it more easy to reuse if need be.