### PR TITLE
fix: fix organization member deletion error

### DIFF
--- a/src/Entity/Organization.php
+++ b/src/Entity/Organization.php
@@ -47,7 +47,7 @@ class Organization implements MercureEntityInterface, \Stringable
 	private ?int $id = null;
 
 	#[ORM\Column(type: 'string', length: 255)]
-	#[Groups(['organization.list', 'organization.read', 'organization.write'])]
+	#[Groups(['organization.list', 'organization.read', 'organization.write', 'member.read'])]
 	private ?string $name = null;
 
 	#[ORM\Column(type: 'string', length: 255)]


### PR DESCRIPTION
Missing information in the member object returned from the API resulted in the impossibility to remove a member from an organization. This fixes the issue by adding the missing data in the OrganizationMember returned from the API.