### PR TITLE
feat: test specific page or subsite when project URL has a path

### DIFF
--- a/src/Util/Sitemap/Crawler.php
+++ b/src/Util/Sitemap/Crawler.php
@@ -11,6 +11,7 @@ use VDB\Spider\Discoverer\XPathExpressionDiscoverer;
 use VDB\Spider\Event\SpiderEvents;
 use VDB\Spider\EventListener\PolitenessPolicyListener;
 use VDB\Spider\Filter\Prefetch\AllowedHostsFilter;
+use VDB\Spider\Filter\Prefetch\RestrictToBaseUriFilter;
 use VDB\Spider\Filter\Prefetch\UriFilter;
 use VDB\Spider\Filter\Prefetch\UriWithHashFragmentFilter;
 use VDB\Spider\QueueManager\InMemoryQueueManager;
@@ -55,6 +56,7 @@ class Crawler
 
 		// Filter out URLs from external domains
 		$spider->getDiscovererSet()->addFilter(new AllowedHostsFilter([$websiteUrl], false));
+		$spider->getDiscovererSet()->addFilter(new RestrictToBaseUriFilter($websiteUrl));
 
 		// Filter out URLs with anchors
 		$spider->getDiscovererSet()->addFilter(new UriWithHashFragmentFilter());

--- a/translations/messages.en.yaml
+++ b/translations/messages.en.yaml
@@ -859,7 +859,7 @@ project_settings:
                     label: Project name
                     placeholder: My awesome project
                 url:
-                    label: Website URL
+                    label: Website or page URL
                     placeholder: www.domain.com
                     error_unreachable: This URL is invalid or unreachable.
                 ignore:


### PR DESCRIPTION
It's finally here: you can test a single page or sub-site at a time! 🎉

Simply specify the page's URL when creating a project, and only that page and its subpages will be included in your project.

**Example #1: testing a single page**
- I want to test only the new page I just created.
- I create a project with that specific page's URL `https://www.mysite.com/my-new-page`.
- Koalati will crawl and include only your `/my-new-page` page. Perfect! ✨

**Example #2: testing part of a site**
- I want to test only the French version of my site.
- I create a project with the URL `https://www.mysite.com/fr`.
- Koalati will crawl and include only pages that start with the `/fr` path. Perfect! ✨