### PR TITLE
fix: restore demo checklist

### DIFF
--- a/assets/app/checklist/demo-checklist.js
+++ b/assets/app/checklist/demo-checklist.js
@@ -115,7 +115,7 @@ export class DemoChecklist extends LitElement
 
 		for (const group of groups) {
 			for (const item of group.items) {
-				item.isCompleted = progressObject[item.id] ?? false;
+				item.is_completed = progressObject[item.id] ?? false;
 			}
 		}
 

--- a/src/Controller/Public/DemoChecklistController.php
+++ b/src/Controller/Public/DemoChecklistController.php
@@ -3,10 +3,14 @@
 namespace App\Controller\Public;
 
 use App\Controller\AbstractController;
+use App\Entity\Project;
 use App\Util\Checklist\Generator;
 use App\Util\ClientMessageSerializer;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Contracts\Cache\ItemInterface;
 
 class DemoChecklistController extends AbstractController
 {
@@ -14,14 +18,35 @@ class DemoChecklistController extends AbstractController
 	 * @SuppressWarnings(PHPMD.UnusedFormalParameter)
 	 */
 	#[Route(path: '/free-checklist', name: 'checklist_demo')]
-	public function checklistDemo(Generator $checklistGenerator, ClientMessageSerializer $serializer): Response
+	public function checklistDemo(Generator $checklistGenerator, ClientMessageSerializer $serializer, EntityManagerInterface $entityManager): Response
 	{
-		// @FIXME: This does not work with the new serializer, since the items/groups don't have IDs
-		// $checklist = $checklistGenerator->generateChecklist(null);
-		// $serializedItemGroups = $serializer->serialize($checklist->getItemGroups());
+		// The serializer does not like resources without IDs.
+		// To get around this, we'll just create a project & checklist in an
+		// SQL transaction, serialize the data, and then rollback the transaction.
+		// To avoid doing this too often, we cache this for a 30-day duration.
+		$cache = new FilesystemAdapter();
+		$serializedItemGroups = $cache->get('demo_checklist', function (ItemInterface $item) use ($checklistGenerator, $serializer, $entityManager) {
+			$item->expiresAfter(3600 * 24 * 30);
+
+			$project = (new Project())
+				->setName("Temporary checklist project")
+				->setUrl("https://sample.koalati.com");
+			$checklist = $checklistGenerator->generateChecklist($project);
+
+			$entityManager->beginTransaction();
+			$entityManager->persist($project);
+			$entityManager->persist($checklist);
+			$entityManager->flush();
+
+			$serializedItemGroups = $serializer->serialize($checklist->getItemGroups(), ['checklist.read']);
+
+			$entityManager->rollback();
+
+			return $serializedItemGroups;
+		});
 
 		return $this->render('public/checklist_demo.html.twig', [
-				"serializedItemGroups" => [], // $serializedItemGroups,
+				"serializedItemGroups" => $serializedItemGroups,
 			]);
 	}
 }


### PR DESCRIPTION
The public checklist demo had been broken since the introduction of the new API (because the new serializer it introduced does not work with resources that do not have IDs).

This PR brings back the demo checklist :)