### PR TITLE
fix: access check for team settings

### DIFF
--- a/src/Controller/Organization/OrganizationController.php
+++ b/src/Controller/Organization/OrganizationController.php
@@ -107,7 +107,7 @@ class OrganizationController extends AbstractController
 				$hasOtherAdmin = false;
 
 				foreach ($organization->getMembers() as $otherMember) {
-					if ($otherMember != $membership && $otherMember->getHighestRole() == OrganizationMember::ROLE_ADMIN) {
+					if ($otherMember != $membership && in_array($otherMember->getHighestRole(), [OrganizationMember::ROLE_OWNER, OrganizationMember::ROLE_ADMIN])) {
 						$hasOtherAdmin = true;
 						break;
 					}


### PR DESCRIPTION
When a team only contained a single admin other than the owner, the admin couldn't leave the team because of a broken condition logic.

This fixes the issue.